### PR TITLE
Add GDP boxplot for each country

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 pandas
+matplotlib

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import math
 from pathlib import Path
+import matplotlib.pyplot as plt
 
 # Set the title and favicon that appear in the Browser's tab bar.
 st.set_page_config(
@@ -116,6 +117,19 @@ st.line_chart(
     color='Country Code',
 )
 
+st.header('GDP distribution by country', divider='gray')
+
+boxplot_data = [
+    filtered_gdp_df[filtered_gdp_df['Country Code'] == c]['GDP'].dropna()
+    for c in selected_countries
+]
+fig, ax = plt.subplots()
+ax.boxplot(boxplot_data, labels=selected_countries)
+ax.set_xlabel('Country')
+ax.set_ylabel('GDP')
+st.pyplot(fig)
+plt.close(fig)
+
 ''
 ''
 
@@ -159,3 +173,4 @@ for i, country in enumerate(selected_countries):
             delta=growth,
             delta_color=delta_color
         )
+


### PR DESCRIPTION
## Summary
- use matplotlib for new visualizations
- visualize GDP distribution per country after the line chart
- update requirements

## Testing
- `python -m py_compile streamlit_app.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68408024d04c8331b59ab6f011c9726a