### PR TITLE
Add GDP year box plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # :earth_americas: GDP dashboard template
 
 A simple Streamlit app showing the GDP of different countries in the world.
+In addition to a line chart, the dashboard displays box plots for GDP
+distribution by country and by year.
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://gdp-dashboard-template.streamlit.app/)
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -130,6 +130,20 @@ ax.set_ylabel('GDP')
 st.pyplot(fig)
 plt.close(fig)
 
+st.header('GDP distribution by year', divider='gray')
+
+years = list(range(from_year, to_year + 1))
+year_boxplot_data = [
+    filtered_gdp_df[filtered_gdp_df['Year'] == y]['GDP'].dropna()
+    for y in years
+]
+fig2, ax2 = plt.subplots(figsize=(max(6, len(years) * 0.3), 4))
+ax2.boxplot(year_boxplot_data, labels=years)
+ax2.set_xlabel('Year')
+ax2.set_ylabel('GDP')
+st.pyplot(fig2)
+plt.close(fig2)
+
 ''
 ''
 


### PR DESCRIPTION
## Summary
- show GDP boxplot for every year in the selected range
- document boxplot graphs in the README

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6888b55d0ef483319f24b3a5676fadb2